### PR TITLE
Fix _BinaryFunction typedef to only check arity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2+4
+
+* Fix the check for `onConnection` to check the number of arguments  and not
+  that the arguments are `dynamic`.
+
 ## 0.2.2+3
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/lib/shelf_web_socket.dart
+++ b/lib/shelf_web_socket.dart
@@ -7,8 +7,7 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 
 import 'src/web_socket_handler.dart';
 
-/// A typedef used to determine if a function takes two arguments or not.
-typedef _BinaryFunction(arg1, arg2);
+typedef _BinaryFunction = void Function(Null, Null);
 
 /// Creates a Shelf handler that upgrades HTTP requests to WebSocket
 /// connections.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shelf_web_socket
-version: 0.2.2+3
+version: 0.2.2+4
 
 description: A WebSocket handler for Shelf.
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
Fixes #11

Update to the new Function syntax and drop the comment which effectively
only repeats the name.