### PR TITLE
Fixed issues with README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `shelf_web_socket` is a [Shelf][] handler for establishing [WebSocket][]
 connections. It exposes a single function, [webSocketHandler][], which calls an
-`onConnection` callback with a [CompatibleWebSocket][] object for every
+`onConnection` callback with a [WebSocketChannel][] object for every
 connection that's established.
 
 [Shelf]: https://pub.dartlang.org/packages/shelf
@@ -11,11 +11,12 @@ connection that's established.
 
 [webSocketHandler]: https://pub.dartlang.org/documentation/shelf_web_socket/latest/shelf_web_socket/webSocketHandler.html
 
-[CompatibleWebSocket]: https://api.dartlang.org/apidocs/channels/be/dartdoc-viewer/http_parser/http_parser.CompatibleWebSocket
+[WebSocketChannel]: https://pub.dartlang.org/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel-class.html
 
 ```dart
 import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_web_socket/shelf_web_socket.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() {
   var handler = webSocketHandler((webSocket) {

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import 'package:shelf_web_socket/shelf_web_socket.dart';
 void main() {
   var handler = webSocketHandler((webSocket) {
     webSocket.stream.listen((message) {
-      webSocket.add("echo $message");
+      webSocket.sink.add("echo $message");
     });
   });
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ connection that's established.
 
 [WebSocket]: https://tools.ietf.org/html/rfc6455
 
-[webSocketHandler]: https://api.dartlang.org/apidocs/channels/be/dartdoc-viewer/shelf_web_socket/shelf_web_socket.webSocketHandler
+[webSocketHandler]: https://pub.dartlang.org/documentation/shelf_web_socket/latest/shelf_web_socket/webSocketHandler.html
 
 [CompatibleWebSocket]: https://api.dartlang.org/apidocs/channels/be/dartdoc-viewer/http_parser/http_parser.CompatibleWebSocket
 


### PR DESCRIPTION
I have fixed the following three issues that were present in the README for this repository...

- Two of the links to documentation were broken; I have replaced them with working links.
- The callback function for `webSocketHandler` is passed a `WebSocketChannel`, not a `CompatibleWebSocket` (I have also imported the `web_socket_channel` library).
- As `webSocket` is a `WebSocketChannel`, we must access the `WebSocketSink` before using `.add`.