### PR TITLE
Ignore protocol header if handler did not specify allowed protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.4-dev
+
+* Allow omitting `protocols` argument even if the `onConnection` callback takes
+  a second argument.
+
 ## 0.2.3
 
 * Add `pingInterval` argument to `webSocketHandler`, to be passed through

--- a/lib/shelf_web_socket.dart
+++ b/lib/shelf_web_socket.dart
@@ -25,8 +25,8 @@ typedef _BinaryFunction = void Function(Null, Null);
 /// argument. The subprotocol is determined by looking at the client's
 /// `Sec-WebSocket-Protocol` header and selecting the first entry that also
 /// appears in [protocols]. If no subprotocols are shared between the client and
-/// the server, `null` will be passed instead. Note that if [onConnection] takes
-/// two arguments, [protocols] must be passed.
+/// the server, `null` will be passed instead and no subprotocol heaader will be
+/// sent to the client which may cause it to disconnect.
 ///
 /// [WebSocket subprotocol]: https://tools.ietf.org/html/rfc6455#section-1.9
 ///

--- a/lib/shelf_web_socket.dart
+++ b/lib/shelf_web_socket.dart
@@ -46,11 +46,6 @@ Handler webSocketHandler(Function onConnection,
     Iterable<String> allowedOrigins,
     Duration pingInterval}) {
   if (onConnection is! _BinaryFunction) {
-    if (protocols != null) {
-      throw ArgumentError('If protocols is non-null, onConnection must '
-          'take two arguments, the WebSocket and the protocol.');
-    }
-
     var innerOnConnection = onConnection;
     onConnection = (webSocket, _) => innerOnConnection(webSocket);
   }

--- a/lib/src/web_socket_handler.dart
+++ b/lib/src/web_socket_handler.dart
@@ -92,12 +92,12 @@ class WebSocketHandler {
   ///
   /// If no matching protocol can be found, returns `null`.
   String _chooseProtocol(Request request) {
-    var protocols = request.headers['Sec-WebSocket-Protocol'];
-    if (protocols == null) return null;
+    var requestProtocols = request.headers['Sec-WebSocket-Protocol'];
+    if (requestProtocols == null) return null;
     if (_protocols == null) return null;
-    for (var protocol in protocols.split(',')) {
-      protocol = protocol.trim();
-      if (_protocols.contains(protocol)) return protocol;
+    for (var requestProtocol in requestProtocols.split(',')) {
+      requestProtocol = requestProtocol.trim();
+      if (_protocols.contains(requestProtocol)) return requestProtocol;
     }
     return null;
   }

--- a/lib/src/web_socket_handler.dart
+++ b/lib/src/web_socket_handler.dart
@@ -94,6 +94,7 @@ class WebSocketHandler {
   String _chooseProtocol(Request request) {
     var protocols = request.headers['Sec-WebSocket-Protocol'];
     if (protocols == null) return null;
+    if (_protocols == null) return null;
     for (var protocol in protocols.split(',')) {
       protocol = protocol.trim();
       if (_protocols.contains(protocol)) return protocol;

--- a/test/web_socket_test.dart
+++ b/test/web_socket_test.dart
@@ -67,6 +67,22 @@ void main() {
     }
   });
 
+  test('handles protocol header without allowed protocols', () async {
+    var server = await shelf_io.serve(webSocketHandler((webSocket) {
+      webSocket.sink.close();
+    }), 'localhost', 0);
+
+    try {
+      var webSocket = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: ['one', 'two', 'three']);
+      // TODO figure out what should happen if handler didn't specific
+      // protocols.
+      return webSocket.close();
+    } finally {
+      await server.close();
+    }
+  }, skip: 'https://github.com/dart-lang/shelf_web_socket/issues/27');
+
   group('with a set of allowed origins', () {
     HttpServer server;
     Uri url;

--- a/test/web_socket_test.dart
+++ b/test/web_socket_test.dart
@@ -82,6 +82,22 @@ void main() {
     }
   });
 
+  test('allows two argument callbacks without protocols', () async {
+    var server = await shelf_io.serve(webSocketHandler((webSocket, protocol) {
+      expect(protocol, isNull);
+      webSocket.sink.close();
+    }), 'localhost', 0);
+
+    try {
+      var webSocket = await WebSocket.connect('ws://localhost:${server.port}',
+          protocols: ['one', 'two', 'three']);
+      expect(webSocket.protocol, isNull);
+      return webSocket.close();
+    } finally {
+      await server.close();
+    }
+  });
+
   group('with a set of allowed origins', () {
     HttpServer server;
     Uri url;
@@ -184,11 +200,6 @@ void main() {
       headers.remove('Sec-WebSocket-Key');
       expect(http.get(url, headers: headers), hasStatus(400));
     });
-  });
-
-  test('throws an error if a unary function is provided with protocols', () {
-    expect(() => webSocketHandler((_) => null, protocols: ['foo']),
-        throwsArgumentError);
   });
 }
 

--- a/test/web_socket_test.dart
+++ b/test/web_socket_test.dart
@@ -75,13 +75,12 @@ void main() {
     try {
       var webSocket = await WebSocket.connect('ws://localhost:${server.port}',
           protocols: ['one', 'two', 'three']);
-      // TODO figure out what should happen if handler didn't specific
-      // protocols.
+      expect(webSocket.protocol, isNull);
       return webSocket.close();
     } finally {
       await server.close();
     }
-  }, skip: 'https://github.com/dart-lang/shelf_web_socket/issues/27');
+  });
 
   group('with a set of allowed origins', () {
     HttpServer server;


### PR DESCRIPTION
Closes #27

The spec says "if the server does not agree to any of the client's
requested subprotocols, the only acceptable value is null". The mozilla
docs for implementing a web socket server say "The client may close the
connection if it doesn't get the subprotocol it wants."

From this I take it that the safest thing to do is to ignore the
protocols. A server which wants to be more careful can handle the `null`
protocol in whatever way makes sense.